### PR TITLE
docs(git-usage): add commit convention guidelines (see #19)

### DIFF
--- a/documentation/git_usage.md
+++ b/documentation/git_usage.md
@@ -1,0 +1,47 @@
+# "Git Usage"
+
+## Conventional Commits 
+
+### Template
+
+```text
+# Bash code
+<commit type>(<scope>): <concise summary> (<issue/pr reference>)
+```
+
+### Commit Types
+
+| Use Case            | Type     | Description                                                | Example                                         |
+| ------------------- | -------- | ---------------------------------------------------------- | ----------------------------------------------- |
+| Feature Development | feat     | A new feature                                              | feat(valuation): add summary statistics         |
+| Bug Fixing          | fix      | A bug fix                                                  | fix(recreation): correct visitor total bug      |
+| Code Improvements   | refactor | Code changes that don’t add features or fix bugs           | refactor(fisheries-valuation): streamline logic |
+|                     | style    | Formatting, whitespace, or style changes                   | style(condition): format code                   |
+| Maintenance & Ops   | chore    | Routine tasks, config, setup, data processing, maintenance | chore(data): update raw datasets                |
+| Documentation       | docs     | Documentation changes                                      | docs(readme): update setup instructions         |
+| Testing             | test     | Adding or fixing tests                                     | test(extent): add unit tests                    |
+
+### Common Scopes
+
+| Use Case                 | Scope               | Description                                                   | Example                                     |
+| ------------------------ | ------------------- | ------------------------------------------------------------- | ----------------------------------------------------------- |
+| Project Structure        | setup               | Project setup or initial configuration                        | chore(setup): initialize project structure                  |
+|                          | rhino-framework     | Rhino app framework setup, configuration, or maintenance      | feat(rhino-framework): add Rhino initialization (closes #7) |
+| Configuration & Workflow | config              | Configuration files or settings                               | chore(config): update .gitignore for data files             |
+|                          | targets-pipeline    | Workflow pipeline setup, logic, configuration, or maintenance | fix(targets-pipeline): correct target dependency order      |
+| Data Management          | data                | Data import, processing, or storage                           | chore(data): process and update fisheries dataset           |
+| Documentation            | docs                | Documentation changes                                         | docs(docs): update installation instructions                |
+| Domain Modules           | extent              | Extent modules and scripts                                    | refactor(extent): optimize extent calculation               |
+|                          | condition           | Condition modules and scripts                                 | feat(condition): add condition summary report               |
+|                          | fisheries-valuation | Fisheries valuation modules and scripts                       | feat(fisheries-valuation): implement value estimation       |
+|                          | recreation          | Recreation modules and scripts                                | fix(recreation): correct visitor count aggregation          |
+
+### Issue/Pull Request Keywords
+
+| Keyword     | Effect                      | When to Use                                                | Example                         |
+| ----------- | --------------------------- | ---------------------------------------------------------- | ---------------------------------------------- |
+| closes #X   | Closes issue/PR when merged | The commit fully resolves and should close the issue       | feat(data): add CSV import (closes #15)        |
+| fixes #X    | Closes issue/PR when merged | Synonym for `closes`; also closes the issue                | fix(setup): correct install steps (fixes #2)   |
+| resolves #X | Closes issue/PR when merged | Synonym for `closes`; also closes the issue                | refactor(config): cleanup config (resolves #9) |
+| refs #X     | References issue/PR only    | Links the commit to the issue/PR but does **not** close it | chore(data): update dataset (refs #7)          |
+| see #X      | References issue/PR only    | Suggests related work or partial fixes                     | docs(readme): clarify intro (see #4)           |

--- a/documentation/version_control.md
+++ b/documentation/version_control.md
@@ -1,4 +1,4 @@
-# "Git Usage"
+# Git Usage
 
 ## Conventional Commits 
 
@@ -31,6 +31,7 @@
 |                          | targets-pipeline    | Workflow pipeline setup, logic, configuration, or maintenance | fix(targets-pipeline): correct target dependency order      |
 | Data Management          | data                | Data import, processing, or storage                           | chore(data): process and update fisheries dataset           |
 | Documentation            | docs                | Documentation changes                                         | docs(docs): update installation instructions                |
+|               | git-usage | Git workflow, commit conventions, and usage documentation | docs(git-usage): add git usage guidelines document |
 | Domain Modules           | extent              | Extent modules and scripts                                    | refactor(extent): optimize extent calculation               |
 |                          | condition           | Condition modules and scripts                                 | feat(condition): add condition summary report               |
 |                          | fisheries-valuation | Fisheries valuation modules and scripts                       | feat(fisheries-valuation): implement value estimation       |

--- a/documentation/version_control.md
+++ b/documentation/version_control.md
@@ -1,4 +1,6 @@
-# Git Usage
+# Version Control
+
+
 
 ## Conventional Commits 
 
@@ -31,7 +33,7 @@
 |                          | targets-pipeline    | Workflow pipeline setup, logic, configuration, or maintenance | fix(targets-pipeline): correct target dependency order      |
 | Data Management          | data                | Data import, processing, or storage                           | chore(data): process and update fisheries dataset           |
 | Documentation            | docs                | Documentation changes                                         | docs(docs): update installation instructions                |
-|               | git-usage | Git workflow, commit conventions, and usage documentation | docs(git-usage): add git usage guidelines document |
+|               | version-control | Version control workflow, git usage, and commit conventions documentation | docs(version-control): add version control guidelines document |
 | Domain Modules           | extent              | Extent modules and scripts                                    | refactor(extent): optimize extent calculation               |
 |                          | condition           | Condition modules and scripts                                 | feat(condition): add condition summary report               |
 |                          | fisheries-valuation | Fisheries valuation modules and scripts                       | feat(fisheries-valuation): implement value estimation       |


### PR DESCRIPTION
## Description
Outlined the commit message conventions used in this project

## Changes
- Created version control documentation in `documentation/` folder (44e5ff2)
- Added commit convention guidelines (44e5ff2)
- Changed document names to version control instead of git usage to include GitHub workflow too (761f443, cb1c22d)

## Related Issue
See #19